### PR TITLE
for clarat-org/clarat #723 -  Definitions regelmäßig neu generieren

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ ruby '2.2.2'
 gem 'rails', '~> 4.2'
 gem 'bundler', '>= 1.8.4'
 
-gem 'clarat_base', github: 'clarat-org/clarat_base'
+gem 'clarat_base', github: 'clarat-org/clarat_base' # , path: '../clarat_base'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 # gem 'rails', '~> 4.1.12'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/clarat-org/clarat_base.git
-  revision: cfcd0dd58ffef7f6ff70c142a78bf5055882cd65
+  revision: 464bc405e7a93a1ae134785cd0e7c0676b81448a
   specs:
     clarat_base (0.1.4)
       aasm

--- a/app/workers/regenerate_html_worker.rb
+++ b/app/workers/regenerate_html_worker.rb
@@ -2,46 +2,15 @@ class RegenerateHtmlWorker
   include Sidekiq::Worker
   include Sidetiq::Schedulable
 
-  recurrence { daily.hour_of_day(0) }
+  recurrence { weekly.day(:thursday).hour_of_day(0) }
 
   def perform
-    # TODO: TBD what to do about this with translations replacing *_html
-
-    # Offer.approved.find_each do |offer|
-    #   old = { description_html: offer.description_html,
-    #           next_steps_html: offer.next_steps_html,
-    #           opening_specification_html: offer.opening_specification_html }
-    #   offer.generate_html!
-    #   check_and_update(offer, old)
-    # end
-    #
-    # Organization.approved.find_each do |orga|
-    #   old = { description_html: orga.description_html }
-    #   orga.generate_html!
-    #   check_and_update(orga, old)
-    # end
-  end
-
-  private
-
-  # def check_and_update object, old
-  #   actual_changes = changes(object, old)
-  #   object.update_columns actual_changes if actual_changes
-  # end
-
-  def changes object, old
-    news = {}
-    old.each do |field, old_string|
-      new_string = object.send(field)
-      next if new_string == old_string
-      news[field] = new_string
+    Offer.approved.find_each do |offer|
+      TranslationGenerationWorker.perform_async :de, 'Offer', offer.id
     end
 
-    if news.keys.count > 0
-      news[:updated_at] = Time.zone.now
-      return news
-    else
-      return false
+    Organization.approved.find_each do |orga|
+      TranslationGenerationWorker.perform_async :de, 'Organization', orga.id
     end
   end
 end

--- a/test/fixtures/organizations.yml
+++ b/test/fixtures/organizations.yml
@@ -1,7 +1,7 @@
 basic:
   id: 1
   name: foobar
-  description: foobar
+  description: basicOrganizationDescription
   legal_form: ev
   offers_count: 1
   aasm_state: approved

--- a/test/workers/regenerate_html_worker_test.rb
+++ b/test/workers/regenerate_html_worker_test.rb
@@ -4,48 +4,29 @@ class RegenerateHtmlWorkerTest < ActiveSupport::TestCase
   # extend ActiveSupport::TestCase to get fixtures
   let(:worker) { RegenerateHtmlWorker.new }
 
-  describe '#changes' do
-    it 'should register changes in an object' do
-      old = { foo: 'unchanged', bar: 'unchanged' }
-      obj = OpenStruct.new foo: 'unchanged', bar: 'changed'
-
-      result = worker.send(:changes, obj, old)
-
-      result[:foo].must_be :nil?
-      result[:bar].must_equal 'changed'
-      result[:updated_at].wont_be :nil?
-      result.keys.count.must_equal 2
-    end
-
-    it 'should return false when there are no changes' do
-      old = { foo: 'unchanged', bar: 'unchanged' }
-      obj = OpenStruct.new foo: 'unchanged', bar: 'unchanged'
-
-      result = worker.send(:changes, obj, old)
-      result.must_equal false
-    end
-  end
-
   describe 'perform' do
-    # before do
-    #   # Run worker initially so everything in database is updated to the
-    #   # most recent state
-    #   worker.perform
-    # end
-    #
-    # it 'should send an update when there has been a changed offer and orga' do
-    #   FactoryGirl.create :definition, key: offers(:basic).description
-    #   FactoryGirl.create :definition, key: organizations(:basic).description
-    #
-    #   Offer.any_instance.expects(:update_columns)
-    #   Organization.any_instance.expects(:update_columns)
-    #   worker.perform
-    # end
-    #
-    # it 'wont send an update when there has been no changed offer and orga' do
-    #   Offer.any_instance.expects(:update_columns).never
-    #   Organization.any_instance.expects(:update_columns).never
-    #   worker.perform
-    # end
+    before do
+      # Run worker initially so everything in database is updated to the
+      # most recent state
+      worker.perform
+    end
+
+    it 'should regenerate german offer and orga translation' do
+      offer = offers(:basic)
+      orga = organizations(:basic)
+      FactoryGirl.create :definition, key: offer.untranslated_description
+      FactoryGirl.create :definition, key: orga.untranslated_description
+
+      # Doesn't request translations
+      GoogleTranslateCommunicator.expects(:get_translations).never
+      worker.perform
+
+      offer.reload.description.must_include(
+        "<dfn class='JS-tooltip' data-id='1'>basicOfferDescription</dfn>"
+      )
+      orga.reload.description.must_include(
+        "<dfn class='JS-tooltip' data-id='2'>basicOrganizationDescription</dfn>"
+      )
+    end
   end
 end


### PR DESCRIPTION
-> clarat-org/clarat#723
reinstate the regenerate_html_worker and have it run the german TranslationGenerationWorker for all offers and organizations
