### PR TITLE
clarat-org/clarat#1043 moved validation to state machine

### DIFF
--- a/app/models/offer/state_machine.rb
+++ b/app/models/offer/state_machine.rb
@@ -47,6 +47,7 @@ module Offer::StateMachine
       end
 
       event :approve, before: :set_approved_information,
+                      guards: :expiration_date_in_future?,
                       success: :generate_translations! do
         transitions from: :approval_process, to: :seasonal_pending,
                     guard: :seasonal_offer_not_yet_to_be_approved?
@@ -117,6 +118,10 @@ module Offer::StateMachine
 
     def at_least_one_organization_not_visible?
       organizations.where.not(aasm_state: %w(approved all_done)).any?
+    end
+
+    def expiration_date_in_future?
+      self.expires_at > Time.zone.now
     end
 
     def set_approved_information

--- a/test/features/admin_backend_test.rb
+++ b/test/features/admin_backend_test.rb
@@ -276,8 +276,8 @@ feature 'Admin Backend' do
       click_link 'Angebote', match: :first
       click_link 'Bearbeiten', match: :first
 
-      # simulate expired offer in other deactivation state (offer invalid)
-      offer.update_columns aasm_state: 'internal_feedback', expires_at: Time.zone.now - 1.day
+      # simulate invalid age in other deactivation state (offer invalid)
+      offer.update_columns aasm_state: 'internal_feedback', age_from: -1
       offer.valid?.must_equal false
 
       page.must_have_link 'Deaktivieren (External Feedback)'
@@ -306,7 +306,7 @@ feature 'Admin Backend' do
       click_link 'Angebote', match: :first
 
       # simulate expired offer in other deactivation state (offer invalid)
-      offer.update_columns aasm_state: 'completed', expires_at: Time.zone.now - 1.day
+      offer.update_columns aasm_state: 'completed', age_from: -1
       offer.valid?.must_equal false
 
       click_link 'Bearbeiten', match: :first

--- a/test/workers/check_unreachable_offers_worker_test.rb
+++ b/test/workers/check_unreachable_offers_worker_test.rb
@@ -16,8 +16,7 @@ class CheckUnreachableOffersWorkerTest < ActiveSupport::TestCase # to have fixtu
   it 'should NOT re-activate deactivated invalid offer with reachable website' do
     website = FactoryGirl.create :website, :own, unreachable_count: 0
     invalid_offer = FactoryGirl.create :offer, :approved
-    invalid_offer.update_columns aasm_state: 'website_unreachable',
-                                 expires_at: Time.zone.now - 1.day
+    invalid_offer.update_columns aasm_state: 'website_unreachable', age_from: -1
     website.offers << invalid_offer
     Offer.any_instance.expects(:index!).never
     worker.perform


### PR DESCRIPTION
The approved button isn’t rendered so long the expires_at < now.
clarat_base update pull needed